### PR TITLE
add opencode issue triage and scheduled review

### DIFF
--- a/.github/workflows/issues-triage.yml
+++ b/.github/workflows/issues-triage.yml
@@ -1,0 +1,18 @@
+name: issue-triage
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  add-triage-label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Add triage label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          gh issue edit "$ISSUE_NUMBER" --add-label triage

--- a/.github/workflows/opencode-scheduled.yml
+++ b/.github/workflows/opencode-scheduled.yml
@@ -1,0 +1,46 @@
+name: opencode-scheduled
+
+on:
+  schedule:
+    - cron: '0 */12 * * *'
+
+jobs:
+  opencode:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Restore OpenCode credentials
+        env:
+          OPENCODE_AUTH_JSON: ${{ secrets.OPENCODE_AUTH_JSON }}
+        run: |
+          mkdir -p "$HOME/.local/share/opencode"
+          printf '%s' "$OPENCODE_AUTH_JSON" > "$HOME/.local/share/opencode/auth.json"
+          chmod 600 "$HOME/.local/share/opencode/auth.json"
+
+      - name: Configure git author
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Run OpenCode
+        uses: anomalyco/opencode/github@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          model: github-copilot/gpt-5.4
+          use_github_token: true
+          prompt: |
+            Review the codebase for bugs, broken behavior, missing error handling, and TODO comments.
+            Before opening any new issue, review existing open issues and recently closed issues to avoid duplicates.
+            If an equivalent issue already exists, do not open a new one.
+            If you find work worth tracking and no equivalent issue exists, open GitHub issues with clear titles and concise technical descriptions.
+            Use the `bug` label for confirmed defects.

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -5,12 +5,34 @@ on:
     types: [created]
   pull_request_review_comment:
     types: [created]
+  pull_request_review:
+    types: [submitted]
 
 jobs:
   opencode:
     if: |
-      contains(github.event.comment.body, '/oc') ||
-      contains(github.event.comment.body, '/opencode')
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+      ) ||
+      (
+        github.event_name == 'issue_comment' &&
+        !github.event.issue.pull_request &&
+        (
+          contains(github.event.comment.body, '/oc') ||
+          contains(github.event.comment.body, '/opencode')
+        ) &&
+        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+      ) ||
+      (
+        github.event_name == 'pull_request_review_comment' &&
+        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+      ) ||
+      (
+        github.event_name == 'pull_request_review' &&
+        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)
+      )
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -31,6 +53,11 @@ jobs:
           mkdir -p "$HOME/.local/share/opencode"
           printf '%s' "$OPENCODE_AUTH_JSON" > "$HOME/.local/share/opencode/auth.json"
           chmod 600 "$HOME/.local/share/opencode/auth.json"
+
+      - name: Configure git author
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Run OpenCode
         uses: anomalyco/opencode/github@latest

--- a/SETUP_REPO.md
+++ b/SETUP_REPO.md
@@ -3,9 +3,22 @@
 - Add a repository secret named `OPENCODE_AUTH_JSON`.
 - Set its value to the full contents of `~/.local/share/opencode/auth.json` from the machine where OpenCode is already authenticated.
 - This lets the GitHub Actions runner restore OpenCode provider credentials before running the workflow.
+- The workflow also configures a local git author in the runner so commits can be created when using `GITHUB_TOKEN` without the OpenCode GitHub app.
+- The workflow requires `/oc` or `/opencode` in regular issue comments, but pull request comments, pull request review comments, and pull request reviews from `OWNER`, `MEMBER`, or `COLLABORATOR` users trigger OpenCode implicitly.
+- `.github/workflows/opencode-scheduled.yml` reviews the repository every 12 hours and can open tracking issues for bugs or follow-up work.
 
 ```bash
 gh secret set OPENCODE_AUTH_JSON < ~/.local/share/opencode/auth.json
+```
+
+## Labels
+
+- Create the labels `triage` and `bug`.
+- New issues are automatically labeled with `triage` by `.github/workflows/issues-triage.yml`.
+
+```bash
+gh label create triage --color FBCA04 --description "Needs initial triage"
+gh label create bug --color D73A4A --description "Something isn't working"
 ```
 
 ## Repository Merge Settings


### PR DESCRIPTION
## Summary
- add automatic `triage` labeling for newly opened issues
- update OpenCode triggers for implicit PR feedback handling and runner git identity
- add a scheduled OpenCode review workflow that checks the codebase every 12 hours and opens non-duplicate follow-up issues when needed

- closes #2