### PR TITLE
fix opencode comment triggers and setup docs

### DIFF
--- a/.github/workflows/opencode-scheduled.yml
+++ b/.github/workflows/opencode-scheduled.yml
@@ -15,8 +15,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-        with:
-          persist-credentials: false
 
       - name: Restore OpenCode credentials
         env:

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -13,12 +13,6 @@ jobs:
     if: |
       (
         github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request &&
-        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
-      ) ||
-      (
-        github.event_name == 'issue_comment' &&
-        !github.event.issue.pull_request &&
         (
           contains(github.event.comment.body, '/oc') ||
           contains(github.event.comment.body, '/opencode')
@@ -27,10 +21,18 @@ jobs:
       ) ||
       (
         github.event_name == 'pull_request_review_comment' &&
+        (
+          contains(github.event.comment.body, '/oc') ||
+          contains(github.event.comment.body, '/opencode')
+        ) &&
         contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
       ) ||
       (
         github.event_name == 'pull_request_review' &&
+        (
+          contains(github.event.review.body, '/oc') ||
+          contains(github.event.review.body, '/opencode')
+        ) &&
         contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)
       )
     runs-on: ubuntu-latest

--- a/SETUP_REPO.md
+++ b/SETUP_REPO.md
@@ -4,7 +4,8 @@
 - Set its value to the full contents of `~/.local/share/opencode/auth.json` from the machine where OpenCode is already authenticated.
 - This lets the GitHub Actions runner restore OpenCode provider credentials before running the workflow.
 - The workflow also configures a local git author in the runner so commits can be created when using `GITHUB_TOKEN` without the OpenCode GitHub app.
-- The workflow requires `/oc` or `/opencode` in regular issue comments, but pull request comments, pull request review comments, and pull request reviews from `OWNER`, `MEMBER`, or `COLLABORATOR` users trigger OpenCode implicitly.
+- GitHub Actions repository settings must allow `Read and write permissions` for `GITHUB_TOKEN` and enable `Allow GitHub Actions to create and approve pull requests`.
+- The workflow requires `/oc` or `/opencode` in issue comments, pull request comments, pull request review comments, and pull request reviews, and only accepts them from `OWNER`, `MEMBER`, or `COLLABORATOR` users.
 - `.github/workflows/opencode-scheduled.yml` reviews the repository every 12 hours and can open tracking issues for bugs or follow-up work.
 
 ```bash
@@ -19,6 +20,19 @@ gh secret set OPENCODE_AUTH_JSON < ~/.local/share/opencode/auth.json
 ```bash
 gh label create triage --color FBCA04 --description "Needs initial triage"
 gh label create bug --color D73A4A --description "Something isn't working"
+```
+
+## GitHub Actions Permissions
+
+- Set the default `GITHUB_TOKEN` permission level to `Read and write`.
+- Allow GitHub Actions to create and approve pull requests.
+
+```bash
+gh api \
+  --method PUT \
+  "repos/$(gh repo view --json nameWithOwner -q .nameWithOwner)/actions/permissions/workflow" \
+  -f default_workflow_permissions=write \
+  -F can_approve_pull_request_reviews=true
 ```
 
 ## Repository Merge Settings


### PR DESCRIPTION
## Summary
- require `/oc` or `/opencode` in issue comments, PR comments, PR review comments, and PR reviews so the workflow matches OpenCode's built-in trigger validation
- document the required GitHub Actions permissions and keep the scheduled workflow checkout aligned with repository defaults