### PR TITLE
fix opencode retry condition

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -71,7 +71,7 @@ jobs:
 
   opencode-retry:
     needs: opencode
-    if: ${{ needs.opencode.result == 'failure' }}
+    if: ${{ always() && needs.opencode.result != 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:


### PR DESCRIPTION
## Summary
- run the OpenCode retry job whenever the first OpenCode job does not finish successfully
- cover timeout and cancelled outcomes instead of retrying only on explicit failure