### PR TITLE
Bootstrap reviewer via template

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository is the bootstrap source for that command.
 When you run `oc-init`, it:
 
 - resolves the target repo to the git root, even if you launch it from a nested folder
-- copies `AGENTS.md`, `.github/workflows/opencode.yml`, and `.github/workflows/issues-triage.yml`
+- copies `AGENTS.md`, `.github/workflows/opencode.yml`, `.github/workflows/opencode-review.yml`, and `.github/workflows/issues-triage.yml`
 - optionally copies `.github/workflows/opencode-scheduled.yml` when you pass `--with-scheduled`
 - updates `.gitignore` by appending `.worktrees` only when that entry is missing
 - writes `*.oc-init-new` files instead of overwriting existing managed files, unless you pass `--force`
@@ -30,10 +30,13 @@ By default, existing repository content stays in place. `--force` only replaces 
 
 - `AGENTS.md` with repository workflow and contribution guidance for OpenCode sessions.
 - `.github/workflows/opencode.yml` to run OpenCode from issue comments and PR review activity.
+- `.github/workflows/opencode-review.yml` to run a two-pass automated PR review and publish one combined result.
 - `.github/workflows/opencode-scheduled.yml` to perform scheduled repository reviews.
 - `.github/workflows/issues-triage.yml` to label newly opened issues with `triage`.
 - `.gitignore` updated to include the local `.worktrees` convention used by the branching guide.
 - GitHub labels, secret, workflow permissions, PR approval permissions, and merge settings configured through `gh`.
+
+The reviewer workflow source lives at `templates/opencode-review.yml` in this bootstrap repository and is copied into target repositories as `.github/workflows/opencode-review.yml` by `oc-init`.
 
 ## Quick start
 

--- a/oc-init
+++ b/oc-init
@@ -226,6 +226,7 @@ REPO_SLUG=$(resolve_repo_slug "$ORIGIN_URL")
 copy_file 'AGENTS.md' "$TARGET_REPO/AGENTS.md"
 ensure_gitignore_entry "$TARGET_REPO/.gitignore"
 copy_file '.github/workflows/opencode.yml' "$TARGET_REPO/.github/workflows/opencode.yml"
+copy_file 'templates/opencode-review.yml' "$TARGET_REPO/.github/workflows/opencode-review.yml"
 copy_file '.github/workflows/issues-triage.yml' "$TARGET_REPO/.github/workflows/issues-triage.yml"
 
 if [ "$INCLUDE_SCHEDULED" = 'true' ]; then

--- a/templates/opencode-review.yml
+++ b/templates/opencode-review.yml
@@ -1,0 +1,190 @@
+name: opencode-review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: opencode-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Restore OpenCode credentials
+        env:
+          OPENCODE_AUTH_JSON: ${{ secrets.OPENCODE_AUTH_JSON }}
+        run: |
+          mkdir -p "$HOME/.local/share/opencode"
+          printf '%s' "$OPENCODE_AUTH_JSON" > "$HOME/.local/share/opencode/auth.json"
+          chmod 600 "$HOME/.local/share/opencode/auth.json"
+          mkdir -p .opencode/reviews
+
+      - name: First review pass
+        uses: anomalyco/opencode/github@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          model: github-copilot/gpt-5.4
+          use_github_token: true
+          prompt: |
+            Review this pull request:
+            - Check for code quality issues
+            - Look for potential bugs
+            - Suggest improvements
+            - Detect modifications outside the intended PR scope
+            - Explicitly flag changes that should not be allowed because they modify code outside the PR scope
+
+            Work only in the checked out repository and do not publish any GitHub comments, reviews, issues, commits, or pull requests.
+            Write your findings to `.opencode/reviews/pass-1.md`.
+
+            Use this exact format:
+
+            # First Pass Review
+            Decision: NEEDS_CHANGES or LGTM
+
+            ## Summary
+            <1-2 sentences>
+
+            ## Findings
+            - <finding or write "- None.">
+
+            ## Out of Scope
+            - <out-of-scope change or write "- None.">
+
+      - name: Second review pass
+        uses: anomalyco/opencode/github@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          model: github-copilot/claude-opus-4-6
+          use_github_token: true
+          prompt: |
+            Review this pull request again with a second reviewer perspective.
+
+            Before deciding, read `.opencode/reviews/pass-1.md` and incorporate the first reviewer's conclusions into one final combined review.
+
+            Evaluate:
+            - code quality issues
+            - potential bugs
+            - suggested improvements
+            - modifications outside the intended PR scope
+            - changes that should not be allowed because they modify code outside the PR scope
+
+            Work only in the checked out repository and do not publish any GitHub comments, reviews, issues, commits, or pull requests.
+            Overwrite `.opencode/reviews/final.json` with a single valid JSON object using this exact schema:
+
+            {
+              "decision": "needs_changes or lgtm",
+              "summary": "1-2 sentence combined review summary",
+              "findings": [
+                {
+                  "severity": "high or medium or low",
+                  "title": "short title",
+                  "details": "specific explanation and suggested fix"
+                }
+              ],
+              "out_of_scope": [
+                {
+                  "title": "short title",
+                  "details": "why the change is outside scope or should not be allowed"
+                }
+              ]
+            }
+
+            Rules:
+            - Use `decision: needs_changes` if there is any actionable fix or any disallowed out-of-scope change.
+            - Use `decision: lgtm` only when there are no actionable findings and no out-of-scope concerns.
+            - Use empty arrays when there are no findings for a section.
+
+      - name: Publish combined review
+        uses: actions/github-script@v7
+        env:
+          REVIEW_PATH: .opencode/reviews/final.json
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs')
+
+            const marker = '<!-- opencode-review -->'
+            const review = JSON.parse(fs.readFileSync(process.env.REVIEW_PATH, 'utf8'))
+
+            const findings = Array.isArray(review.findings) ? review.findings : []
+            const outOfScope = Array.isArray(review.out_of_scope) ? review.out_of_scope : []
+            const needsChanges = review.decision === 'needs_changes'
+            const summary = review.summary || 'Combined review completed.'
+
+            const lines = [
+              marker,
+              '## OpenCode PR Review',
+              '',
+              summary,
+              ''
+            ]
+
+            if (findings.length > 0) {
+              lines.push('### Findings', '')
+              for (const finding of findings) {
+                const severity = finding.severity ? ` (${finding.severity})` : ''
+                lines.push(`- ${finding.title || 'Finding'}${severity}: ${finding.details || ''}`.trim())
+              }
+              lines.push('')
+            }
+
+            if (outOfScope.length > 0) {
+              lines.push('### Out-of-Scope Changes', '')
+              for (const item of outOfScope) {
+                lines.push(`- ${item.title || 'Out-of-scope change'}: ${item.details || ''}`.trim())
+              }
+              lines.push('')
+            }
+
+            if (needsChanges) {
+              lines.push('Action requested: please address the items above.', '', '/oc')
+            } else {
+              lines.push('LGTM - both review passes did not identify actionable issues.')
+            }
+
+            const body = lines.join('\n')
+            const issue_number = context.issue.number
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              per_page: 100,
+            })
+
+            const existing = comments.find((comment) => {
+              return comment.user?.type === 'Bot' && comment.body?.includes(marker)
+            })
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              })
+              core.info(`Updated review comment ${existing.id}`)
+            } else {
+              const response = await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                body,
+              })
+              core.info(`Created review comment ${response.data.id}`)
+            }


### PR DESCRIPTION
I changed the bootstrap so the PR reviewer workflow is now shipped from a non-workflow source file, which avoids touching `.github/workflows` in this repository while still letting `oc-init` install the real workflow into target repos.

- Added the dual-pass reviewer template at `templates/opencode-review.yml`
- Updated `oc-init:229` to copy that template into `.github/workflows/opencode-review.yml` in the destination repo
- Documented the new installed workflow in `README.md:18`, `README.md:33`, and `README.md:38`
- The new template runs `github-copilot/gpt-5.4` first, then `github-copilot/claude-opus-4-6`, passes the first output through `.opencode/reviews/pass-1.md`, and publishes one combined PR comment
- The final comment includes `/oc` only when the combined result is `needs_changes`; otherwise it posts an `LGTM`-style result

I did not run the workflow itself here, but the diff is limited to `README.md`, `oc-init`, and `templates/opencode-review.yml`.

Natural next steps:
1. Let the automated branch/PR flow publish this change
2. Test `./oc-init --force` in a target repo and open a PR there to verify the installed reviewer workflow end-to-end

Closes #22

<a href="https://opencode.ai/s/5SrZ18YG"><img width="200" alt="New%20session%20-%202026-03-23T08%3A46%3A15.927Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTAzLTIzVDA4OjQ2OjE1LjkyN1o=.png?model=github-copilot/gpt-5.4&version=1.3.0&id=5SrZ18YG" /></a>
[opencode session](https://opencode.ai/s/5SrZ18YG)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/DavidGOrtega/auto-repo/actions/runs/23428733969)