### PR TITLE
Remove stale issues-triage refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository is the bootstrap source for that command.
 When you run `oc-init`, it:
 
 - resolves the target repo to the git root, even if you launch it from a nested folder
-- copies `AGENTS.md`, `.github/workflows/opencode.yml`, and `.github/workflows/issues-triage.yml`
+- copies `AGENTS.md` and `.github/workflows/opencode.yml`
 - optionally copies `.github/workflows/opencode-scheduled.yml` when you pass `--with-scheduled`
 - updates `.gitignore` by appending `.worktrees` only when that entry is missing
 - writes `*.oc-init-new` files instead of overwriting existing managed files, unless you pass `--force`
@@ -31,7 +31,6 @@ By default, existing repository content stays in place. `--force` only replaces 
 - `AGENTS.md` with repository workflow and contribution guidance for OpenCode sessions.
 - `.github/workflows/opencode.yml` to run OpenCode from issue comments and PR review activity.
 - `.github/workflows/opencode-scheduled.yml` to perform scheduled repository reviews.
-- `.github/workflows/issues-triage.yml` to label newly opened issues with `triage`.
 - `.gitignore` updated to include the local `.worktrees` convention used by the branching guide.
 - GitHub labels, secret, workflow permissions, PR approval permissions, and merge settings configured through `gh`.
 

--- a/oc-init
+++ b/oc-init
@@ -226,7 +226,6 @@ REPO_SLUG=$(resolve_repo_slug "$ORIGIN_URL")
 copy_file 'AGENTS.md' "$TARGET_REPO/AGENTS.md"
 ensure_gitignore_entry "$TARGET_REPO/.gitignore"
 copy_file '.github/workflows/opencode.yml' "$TARGET_REPO/.github/workflows/opencode.yml"
-copy_file '.github/workflows/issues-triage.yml' "$TARGET_REPO/.github/workflows/issues-triage.yml"
 
 if [ "$INCLUDE_SCHEDULED" = 'true' ]; then
   copy_file '.github/workflows/opencode-scheduled.yml' "$TARGET_REPO/.github/workflows/opencode-scheduled.yml"


### PR DESCRIPTION
I reconciled the bootstrap/docs mismatch by removing the stale `issues-triage` workflow references that no longer match this repository’s actual contents.

- `README.md:18` now says `oc-init` copies only `AGENTS.md` and `.github/workflows/opencode.yml`, with the scheduled workflow remaining optional.
- `README.md:34` no longer claims `.github/workflows/issues-triage.yml` is included, so the documented installed file set matches `.github/workflows/`.
- `oc-init:229` no longer tries to copy a non-existent `.github/workflows/issues-triage.yml`, which keeps bootstrap behavior aligned with the repo state.
- I verified the resulting diff is limited to `README.md` and `oc-init`; the worktree now shows only those two modified files.

Natural next steps:
1. If you want, I can also tighten the README wording around labels so it is clearer that `triage` is configured via `gh`, not via a workflow.
2. If you want this landed cleanly, I can prepare the commit message next.

Closes #22

<a href="https://opencode.ai/s/fXJ1nL3I"><img width="200" alt="New%20session%20-%202026-03-23T09%3A04%3A19.006Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTAzLTIzVDA5OjA0OjE5LjAwNlo=.png?model=github-copilot/gpt-5.4&version=1.3.0&id=fXJ1nL3I" /></a>
[opencode session](https://opencode.ai/s/fXJ1nL3I)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/DavidGOrtega/auto-repo/actions/runs/23429407700)