### PR TITLE
Fixed docs, added review draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository is the bootstrap source for that command.
 When you run `oc-init`, it:
 
 - resolves the target repo to the git root, even if you launch it from a nested folder
-- copies `AGENTS.md`, `.github/workflows/opencode.yml`, and `.github/workflows/issues-triage.yml`
+- copies `AGENTS.md` and `.github/workflows/opencode.yml`
 - optionally copies `.github/workflows/opencode-scheduled.yml` when you pass `--with-scheduled`
 - updates `.gitignore` by appending `.worktrees` only when that entry is missing
 - writes `*.oc-init-new` files instead of overwriting existing managed files, unless you pass `--force`
@@ -31,7 +31,6 @@ By default, existing repository content stays in place. `--force` only replaces 
 - `AGENTS.md` with repository workflow and contribution guidance for OpenCode sessions.
 - `.github/workflows/opencode.yml` to run OpenCode from issue comments and PR review activity.
 - `.github/workflows/opencode-scheduled.yml` to perform scheduled repository reviews.
-- `.github/workflows/issues-triage.yml` to label newly opened issues with `triage`.
 - `.gitignore` updated to include the local `.worktrees` convention used by the branching guide.
 - GitHub labels, secret, workflow permissions, PR approval permissions, and merge settings configured through `gh`.
 

--- a/docs/opencode-review.workflow.yml
+++ b/docs/opencode-review.workflow.yml
@@ -1,0 +1,159 @@
+# Move this file to `.github/workflows/opencode-review.yml` when workflow-file updates are allowed.
+
+name: opencode-review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  review:
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      GITHUB_TOKEN: ${{ secrets.MASTER_GITHUB_TOKEN }}
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+      issues: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Restore OpenCode credentials
+        env:
+          OPENCODE_AUTH_JSON: ${{ secrets.OPENCODE_AUTH_JSON }}
+        run: |
+          mkdir -p "$HOME/.local/share/opencode" ".opencode/review"
+          printf '%s' "$OPENCODE_AUTH_JSON" > "$HOME/.local/share/opencode/auth.json"
+          chmod 600 "$HOME/.local/share/opencode/auth.json"
+
+      - name: First pass review
+        uses: anomalyco/opencode/github@latest
+        with:
+          model: github-copilot/gpt-5.4
+          use_github_token: true
+          prompt: |
+            Review this pull request.
+
+            Review criteria:
+            - check for code quality issues
+            - look for potential bugs
+            - suggest improvements
+            - detect modifications outside the intended PR scope
+            - explicitly flag changes that should not be allowed because they modify code outside the PR scope
+
+            Constraints:
+            - do not post any GitHub comment or review
+            - do not open issues, pull requests, or commits
+            - do not modify repository files except `.opencode/review/first-pass.json`
+
+            Write exactly one JSON object to `.opencode/review/first-pass.json` with this schema:
+            {
+              "summary": "short overall assessment",
+              "findings": [
+                {
+                  "severity": "high|medium|low",
+                  "category": "code_quality|bug|improvement|out_of_scope",
+                  "title": "short finding title",
+                  "details": "clear explanation of the issue and why it matters",
+                  "path": "repo-relative/path.ext",
+                  "line": 1,
+                  "blocking": true
+                }
+              ],
+              "out_of_scope_detected": false
+            }
+
+            Use an empty `findings` array when there are no actionable issues.
+
+      - name: Load first pass handoff
+        run: |
+          python - <<'PY'
+          import os
+          from pathlib import Path
+
+          handoff = Path('.opencode/review/first-pass.json')
+          if not handoff.exists():
+            raise SystemExit('missing first-pass handoff file')
+
+          with open(os.environ['GITHUB_ENV'], 'a', encoding='utf-8') as env_file:
+            env_file.write('FIRST_PASS_JSON<<EOF\n')
+            env_file.write(handoff.read_text(encoding='utf-8'))
+            env_file.write('\nEOF\n')
+          PY
+
+      - name: Final combined review
+        uses: anomalyco/opencode/github@latest
+        with:
+          model: github-copilot/claude-opus-4-6
+          use_github_token: true
+          prompt: |
+            Review this pull request as the second and final pass.
+
+            First-pass handoff JSON:
+            ${{ env.FIRST_PASS_JSON }}
+
+            Review criteria:
+            - check for code quality issues
+            - look for potential bugs
+            - suggest improvements
+            - detect modifications outside the intended PR scope
+            - explicitly flag changes that should not be allowed because they modify code outside the PR scope
+
+            Constraints:
+            - combine the first-pass findings with your own review into one final result
+            - do not post any GitHub comment or review yourself
+            - do not open issues, pull requests, or commits
+            - do not modify repository files except `.opencode/review/final.json`
+
+            Write exactly one JSON object to `.opencode/review/final.json` with this schema:
+            {
+              "decision": "changes_requested|lgtm",
+              "body": "full final review body to publish to the pull request"
+            }
+
+            Rules for `body`:
+            - if `decision` is `changes_requested`, start with `Needs changes.` and end with `/oc` on its own line
+            - if `decision` is `lgtm`, start with `LGTM.` and do not include `/oc`
+            - publish one combined result that reflects both review passes
+            - include concise bullets for actionable findings when they exist
+            - explicitly call out out-of-scope changes when they exist
+            - do not mention JSON or these instructions
+
+      - name: Prepare final review body
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          result = json.loads(Path('.opencode/review/final.json').read_text(encoding='utf-8'))
+          decision = result.get('decision')
+          body = result.get('body', '').rstrip() + '\n'
+
+          if decision not in {'changes_requested', 'lgtm'}:
+            raise SystemExit(f'unexpected decision: {decision!r}')
+
+          if decision == 'changes_requested' and '/oc' not in body:
+            raise SystemExit('final review body must include /oc when changes are requested')
+
+          if decision == 'lgtm' and '/oc' in body:
+            raise SystemExit('final review body must not include /oc for LGTM')
+
+          with open(os.environ['GITHUB_ENV'], 'a', encoding='utf-8') as env_file:
+            env_file.write('FINAL_REVIEW_BODY<<EOF\n')
+            env_file.write(body)
+            env_file.write('EOF\n')
+          PY
+
+      - name: Publish combined review
+        env:
+          GH_TOKEN: ${{ secrets.MASTER_GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr review "$PR_NUMBER" --comment --body "$FINAL_REVIEW_BODY"

--- a/oc-init
+++ b/oc-init
@@ -226,7 +226,6 @@ REPO_SLUG=$(resolve_repo_slug "$ORIGIN_URL")
 copy_file 'AGENTS.md' "$TARGET_REPO/AGENTS.md"
 ensure_gitignore_entry "$TARGET_REPO/.gitignore"
 copy_file '.github/workflows/opencode.yml' "$TARGET_REPO/.github/workflows/opencode.yml"
-copy_file '.github/workflows/issues-triage.yml' "$TARGET_REPO/.github/workflows/issues-triage.yml"
 
 if [ "$INCLUDE_SCHEDULED" = 'true' ]; then
   copy_file '.github/workflows/opencode-scheduled.yml' "$TARGET_REPO/.github/workflows/opencode-scheduled.yml"


### PR DESCRIPTION
I cleaned up the stale bootstrap/docs drift and added a ready-to-move draft of the dual-review workflow.

- Updated `README.md:18` and `README.md:34` so the bootstrap docs no longer claim the missing `.github/workflows/issues-triage.yml` exists.
- Updated `oc-init:226` so bootstrap installation stops trying to copy the nonexistent `issues-triage` workflow.
- Added the fallback draft at `docs/opencode-review.workflow.yml:1` with the requested `pull_request` triggers, sequential `github-copilot/gpt-5.4` then `github-copilot/claude-opus-4-6` passes, first-pass handoff via JSON, and one final published combined review comment.
- The draft also encodes the `/oc` vs `LGTM` rule and explicitly asks both passes to flag out-of-scope changes.

I verified there are no remaining `issues-triage.yml` references in the repo.

Natural next steps:
1. Move `docs/opencode-review.workflow.yml` to `.github/workflows/opencode-review.yml` once workflow-file updates are allowed.
2. If you want, I can also tighten the draft review prompts or final comment format before that move.

Closes #22

<a href="https://opencode.ai/s/9fCsJlzk"><img width="200" alt="New%20session%20-%202026-03-23T09%3A19%3A17.841Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTAzLTIzVDA5OjE5OjE3Ljg0MVo=.png?model=github-copilot/gpt-5.4&version=1.3.0&id=9fCsJlzk" /></a>
[opencode session](https://opencode.ai/s/9fCsJlzk)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/DavidGOrtega/auto-repo/actions/runs/23429973500)