### PR TITLE
Fixed stale issues-triage references

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository is the bootstrap source for that command.
 When you run `oc-init`, it:
 
 - resolves the target repo to the git root, even if you launch it from a nested folder
-- copies `AGENTS.md`, `.github/workflows/opencode.yml`, and `.github/workflows/issues-triage.yml`
+- copies `AGENTS.md` and `.github/workflows/opencode.yml`
 - optionally copies `.github/workflows/opencode-scheduled.yml` when you pass `--with-scheduled`
 - updates `.gitignore` by appending `.worktrees` only when that entry is missing
 - writes `*.oc-init-new` files instead of overwriting existing managed files, unless you pass `--force`
@@ -31,7 +31,6 @@ By default, existing repository content stays in place. `--force` only replaces 
 - `AGENTS.md` with repository workflow and contribution guidance for OpenCode sessions.
 - `.github/workflows/opencode.yml` to run OpenCode from issue comments and PR review activity.
 - `.github/workflows/opencode-scheduled.yml` to perform scheduled repository reviews.
-- `.github/workflows/issues-triage.yml` to label newly opened issues with `triage`.
 - `.gitignore` updated to include the local `.worktrees` convention used by the branching guide.
 - GitHub labels, secret, workflow permissions, PR approval permissions, and merge settings configured through `gh`.
 

--- a/oc-init
+++ b/oc-init
@@ -226,8 +226,6 @@ REPO_SLUG=$(resolve_repo_slug "$ORIGIN_URL")
 copy_file 'AGENTS.md' "$TARGET_REPO/AGENTS.md"
 ensure_gitignore_entry "$TARGET_REPO/.gitignore"
 copy_file '.github/workflows/opencode.yml' "$TARGET_REPO/.github/workflows/opencode.yml"
-copy_file '.github/workflows/issues-triage.yml' "$TARGET_REPO/.github/workflows/issues-triage.yml"
-
 if [ "$INCLUDE_SCHEDULED" = 'true' ]; then
   copy_file '.github/workflows/opencode-scheduled.yml' "$TARGET_REPO/.github/workflows/opencode-scheduled.yml"
 fi


### PR DESCRIPTION
Updated the stale bootstrap/docs references so the repo now matches its current installed workflows.

- Removed the missing `issues-triage` workflow from the `oc-init` behavior docs in `README.md:18` and `README.md:34`
- Stopped `oc-init` from trying to copy the nonexistent file in `oc-init:226`
- Verified there are no remaining `issues-triage.yml` references in `README.md` or `oc-init`

I did not add `opencode-review`; that still depends on workflow-file updates being allowed.

Natural next steps:
1. Add `.github/workflows/opencode-review.yml` once workflow updates are permitted
2. If you want, I can also stage the exact dual-review workflow content in a non-workflow path for later move-in

Closes #22

<a href="https://opencode.ai/s/bAXkfSG5"><img width="200" alt="New%20session%20-%202026-03-23T09%3A29%3A04.859Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTAzLTIzVDA5OjI5OjA0Ljg1OVo=.png?model=github-copilot/gpt-5.4&version=1.3.0&id=bAXkfSG5" /></a>
[opencode session](https://opencode.ai/s/bAXkfSG5)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/DavidGOrtega/auto-repo/actions/runs/23430367890)