### PR TITLE
Fix docs drift, add review draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository is the bootstrap source for that command.
 When you run `oc-init`, it:
 
 - resolves the target repo to the git root, even if you launch it from a nested folder
-- copies `AGENTS.md`, `.github/workflows/opencode.yml`, and `.github/workflows/issues-triage.yml`
+- copies `AGENTS.md` and `.github/workflows/opencode.yml`
 - optionally copies `.github/workflows/opencode-scheduled.yml` when you pass `--with-scheduled`
 - updates `.gitignore` by appending `.worktrees` only when that entry is missing
 - writes `*.oc-init-new` files instead of overwriting existing managed files, unless you pass `--force`
@@ -31,7 +31,6 @@ By default, existing repository content stays in place. `--force` only replaces 
 - `AGENTS.md` with repository workflow and contribution guidance for OpenCode sessions.
 - `.github/workflows/opencode.yml` to run OpenCode from issue comments and PR review activity.
 - `.github/workflows/opencode-scheduled.yml` to perform scheduled repository reviews.
-- `.github/workflows/issues-triage.yml` to label newly opened issues with `triage`.
 - `.gitignore` updated to include the local `.worktrees` convention used by the branching guide.
 - GitHub labels, secret, workflow permissions, PR approval permissions, and merge settings configured through `gh`.
 

--- a/docs/opencode-review.workflow.yml
+++ b/docs/opencode-review.workflow.yml
@@ -1,0 +1,115 @@
+name: opencode-review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+      issues: read
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REVIEW_DIR: .opencode-review
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Prepare review workspace
+        run: mkdir -p "$REVIEW_DIR"
+
+      - name: First review pass with GPT-5.4
+        uses: anomalyco/opencode/github@latest
+        with:
+          model: github-copilot/gpt-5.4
+          use_github_token: true
+          prompt: |
+            Review this pull request:
+            - Check for code quality issues
+            - Look for potential bugs
+            - Suggest improvements
+            - Detect modifications outside the intended PR scope
+            - Explicitly flag changes that should not be allowed because they modify code outside the PR scope
+
+            Write the review to `.opencode-review/pass1.md`.
+
+            File requirements:
+            - Start with `# First Pass Review`
+            - Include a `## Verdict` section containing exactly one of: `changes_requested` or `lgtm`
+            - Include a `## Findings` section with concise bullets
+            - Include a `## Out-of-Scope Changes` section; write `- none` when nothing is out of scope
+            - Do not post a GitHub comment or review in this pass
+            - Do not modify any other files
+
+      - name: Capture first pass output
+        id: pass1
+        shell: bash
+        run: |
+          {
+            echo 'review<<EOF'
+            cat "$REVIEW_DIR/pass1.md"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Second review pass with Claude Opus 4.6
+        uses: anomalyco/opencode/github@latest
+        with:
+          model: github-copilot/claude-opus-4-6
+          use_github_token: true
+          prompt: |
+            Review this pull request as the second reviewer.
+
+            Review criteria:
+            - code quality issues
+            - potential bugs
+            - suggested improvements
+            - modifications outside the intended PR scope
+            - changes that should not be allowed because they modify code outside the PR scope
+
+            Use the first pass review below as additional context, not as ground truth. Confirm, refine, or overturn findings based on the actual pull request diff.
+
+            First pass review:
+            ${{ steps.pass1.outputs.review }}
+
+            Write the final combined review to `.opencode-review/final.md`.
+
+            File requirements:
+            - The first line must be exactly `VERDICT: changes_requested` or `VERDICT: lgtm`
+            - After the first line, leave one blank line and then write the final GitHub comment in Markdown
+            - The comment must combine both review passes into one final outcome
+            - Include a short LGTM-style conclusion when the verdict is `lgtm`
+            - Include `/oc` on its own line at the end only when the verdict is `changes_requested`
+            - Do not include `/oc` when the verdict is `lgtm`
+            - Include any out-of-scope changes in a dedicated section; write `- none` when there are none
+            - Do not post a GitHub comment or review in this pass
+            - Do not modify any other files
+
+      - name: Publish combined review comment
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        shell: bash
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          review_path = Path('.opencode-review/final.md')
+          content = review_path.read_text()
+          first_line, _, body = content.partition('\n')
+
+          if first_line.strip() not in {
+              'VERDICT: changes_requested',
+              'VERDICT: lgtm',
+          }:
+              raise SystemExit('invalid verdict line in .opencode-review/final.md')
+
+          Path('.opencode-review/comment.md').write_text(body.lstrip('\n'))
+          PY
+
+          gh pr comment "$PR_NUMBER" --body-file "$REVIEW_DIR/comment.md"

--- a/oc-init
+++ b/oc-init
@@ -226,7 +226,6 @@ REPO_SLUG=$(resolve_repo_slug "$ORIGIN_URL")
 copy_file 'AGENTS.md' "$TARGET_REPO/AGENTS.md"
 ensure_gitignore_entry "$TARGET_REPO/.gitignore"
 copy_file '.github/workflows/opencode.yml' "$TARGET_REPO/.github/workflows/opencode.yml"
-copy_file '.github/workflows/issues-triage.yml' "$TARGET_REPO/.github/workflows/issues-triage.yml"
 
 if [ "$INCLUDE_SCHEDULED" = 'true' ]; then
   copy_file '.github/workflows/opencode-scheduled.yml' "$TARGET_REPO/.github/workflows/opencode-scheduled.yml"


### PR DESCRIPTION
Cleaned up the stale bootstrap/docs drift and staged the dual-review workflow as a draft outside `.github/workflows/`.

- Removed the obsolete `.github/workflows/issues-triage.yml` references from `README.md:18`, `README.md:34`, and `oc-init:229` so the repo description matches the files that actually exist.
- Added the draft PR reviewer workflow at `docs/opencode-review.workflow.yml:1` instead of `.github/workflows/opencode-review.yml`, which keeps it non-active but ready.
- The draft preserves the explicit prompt-driven review flow, runs `github-copilot/gpt-5.4` first, passes that output into `github-copilot/claude-opus-4-6`, and publishes one final combined PR comment.
- The final comment logic is set up so `changes_requested` appends `/oc`, while `lgtm` omits it, and both passes explicitly check for out-of-scope changes.

I also verified there are now no remaining `issues-triage.yml` references in the repo.

Natural next step:
1. Move `docs/opencode-review.workflow.yml` to `.github/workflows/opencode-review.yml` once workflow-file updates are allowed.

Closes #22

<a href="https://opencode.ai/s/Vn6H23pn"><img width="200" alt="New%20session%20-%202026-03-23T09%3A27%3A20.744Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTAzLTIzVDA5OjI3OjIwLjc0NFo=.png?model=github-copilot/gpt-5.4&version=1.3.0&id=Vn6H23pn" /></a>
[opencode session](https://opencode.ai/s/Vn6H23pn)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/DavidGOrtega/auto-repo/actions/runs/23430269629)