### PR TITLE
Fix bootstrap/docs workflow drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository is the bootstrap source for that command.
 When you run `oc-init`, it:
 
 - resolves the target repo to the git root, even if you launch it from a nested folder
-- copies `AGENTS.md`, `.github/workflows/opencode.yml`, and `.github/workflows/issues-triage.yml`
+- copies `AGENTS.md` and `.github/workflows/opencode.yml`
 - optionally copies `.github/workflows/opencode-scheduled.yml` when you pass `--with-scheduled`
 - updates `.gitignore` by appending `.worktrees` only when that entry is missing
 - writes `*.oc-init-new` files instead of overwriting existing managed files, unless you pass `--force`
@@ -31,7 +31,6 @@ By default, existing repository content stays in place. `--force` only replaces 
 - `AGENTS.md` with repository workflow and contribution guidance for OpenCode sessions.
 - `.github/workflows/opencode.yml` to run OpenCode from issue comments and PR review activity.
 - `.github/workflows/opencode-scheduled.yml` to perform scheduled repository reviews.
-- `.github/workflows/issues-triage.yml` to label newly opened issues with `triage`.
 - `.gitignore` updated to include the local `.worktrees` convention used by the branching guide.
 - GitHub labels, secret, workflow permissions, PR approval permissions, and merge settings configured through `gh`.
 

--- a/oc-init
+++ b/oc-init
@@ -226,7 +226,6 @@ REPO_SLUG=$(resolve_repo_slug "$ORIGIN_URL")
 copy_file 'AGENTS.md' "$TARGET_REPO/AGENTS.md"
 ensure_gitignore_entry "$TARGET_REPO/.gitignore"
 copy_file '.github/workflows/opencode.yml' "$TARGET_REPO/.github/workflows/opencode.yml"
-copy_file '.github/workflows/issues-triage.yml' "$TARGET_REPO/.github/workflows/issues-triage.yml"
 
 if [ "$INCLUDE_SCHEDULED" = 'true' ]; then
   copy_file '.github/workflows/opencode-scheduled.yml' "$TARGET_REPO/.github/workflows/opencode-scheduled.yml"


### PR DESCRIPTION
I cleaned up the bootstrap/docs drift so the repo now matches the workflows that actually exist.

- `README.md:18` now says `oc-init` copies only `AGENTS.md` and `.github/workflows/opencode.yml`.
- `README.md:34` no longer claims the repo includes `.github/workflows/issues-triage.yml`, which is not present.
- `oc-init:229` no longer tries to copy the missing `.github/workflows/issues-triage.yml`, so bootstrap behavior matches the repository contents.

I also verified:
- `.github/workflows/` still only contains `.github/workflows/opencode.yml` and `.github/workflows/opencode-scheduled.yml`
- there are no remaining `issues-triage.yml` references in `README.md` or `oc-init`

Natural next steps:
1. Review this cleanup diff as a separate consistency fix.
2. Add the actual `opencode-review` workflow once workflow-file updates are allowed in the target environment.

Closes #22

<a href="https://opencode.ai/s/fRoyFjRj"><img width="200" alt="New%20session%20-%202026-03-23T09%3A32%3A09.790Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTAzLTIzVDA5OjMyOjA5Ljc5MFo=.png?model=github-copilot/gpt-5.4&version=1.3.0&id=fRoyFjRj" /></a>
[opencode session](https://opencode.ai/s/fRoyFjRj)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/DavidGOrtega/auto-repo/actions/runs/23430474196)