### PR TITLE
Fix bootstrap docs, stage review draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository is the bootstrap source for that command.
 When you run `oc-init`, it:
 
 - resolves the target repo to the git root, even if you launch it from a nested folder
-- copies `AGENTS.md`, `.github/workflows/opencode.yml`, and `.github/workflows/issues-triage.yml`
+- copies `AGENTS.md` and `.github/workflows/opencode.yml`
 - optionally copies `.github/workflows/opencode-scheduled.yml` when you pass `--with-scheduled`
 - updates `.gitignore` by appending `.worktrees` only when that entry is missing
 - writes `*.oc-init-new` files instead of overwriting existing managed files, unless you pass `--force`
@@ -31,9 +31,10 @@ By default, existing repository content stays in place. `--force` only replaces 
 - `AGENTS.md` with repository workflow and contribution guidance for OpenCode sessions.
 - `.github/workflows/opencode.yml` to run OpenCode from issue comments and PR review activity.
 - `.github/workflows/opencode-scheduled.yml` to perform scheduled repository reviews.
-- `.github/workflows/issues-triage.yml` to label newly opened issues with `triage`.
 - `.gitignore` updated to include the local `.worktrees` convention used by the branching guide.
 - GitHub labels, secret, workflow permissions, PR approval permissions, and merge settings configured through `gh`.
+
+This repository may also keep draft workflow content under `docs/` when a workflow file cannot yet be added under `.github/workflows/`.
 
 ## Quick start
 

--- a/docs/opencode-review.workflow.yml
+++ b/docs/opencode-review.workflow.yml
@@ -1,0 +1,97 @@
+name: opencode-review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  first-pass:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read
+      issues: read
+    outputs:
+      review: ${{ steps.capture.outputs.review }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - id: review
+        uses: anomalyco/opencode/github@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          model: github-copilot/gpt-5.4
+          use_github_token: true
+          prompt: |
+            Review this pull request.
+
+            Focus on:
+            - code quality issues
+            - potential bugs
+            - suggested improvements
+            - modifications outside the intended PR scope
+            - changes that should not be allowed because they modify code outside the PR scope
+
+            Return JSON with this shape:
+            {
+              "summary": "short overall assessment",
+              "issues": [
+                {
+                  "severity": "high|medium|low",
+                  "path": "file path or empty string",
+                  "title": "short title",
+                  "details": "why it matters"
+                }
+              ],
+              "lgtm": true
+            }
+
+      - id: capture
+        shell: bash
+        run: |
+          review_file=$(mktemp)
+          cat <<'EOF' > "$review_file"
+          ${{ steps.review.outputs.result }}
+          EOF
+          review_json=$(python -c 'import json, pathlib, sys; print(json.dumps(pathlib.Path(sys.argv[1]).read_text()))' "$review_file")
+          printf 'review=%s\n' "$review_json" >> "$GITHUB_OUTPUT"
+
+  combined-review:
+    needs: first-pass
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+      issues: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - id: review
+        uses: anomalyco/opencode/github@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          model: github-copilot/claude-opus-4.6
+          use_github_token: true
+          prompt: |
+            Review this pull request using the first reviewer output as additional context.
+
+            First reviewer output:
+            ${{ fromJson(needs.first-pass.outputs.review) }}
+
+            Produce one final combined review.
+
+            Requirements:
+            - include findings from both review passes
+            - call out code quality issues, potential bugs, and suggested improvements
+            - explicitly flag modifications outside the intended PR scope
+            - explicitly flag changes that should not be allowed because they modify code outside the PR scope
+            - if fixes are needed, end the review with `/oc`
+            - if no fixes are needed, return an LGTM-style review and do not include `/oc`

--- a/oc-init
+++ b/oc-init
@@ -226,7 +226,6 @@ REPO_SLUG=$(resolve_repo_slug "$ORIGIN_URL")
 copy_file 'AGENTS.md' "$TARGET_REPO/AGENTS.md"
 ensure_gitignore_entry "$TARGET_REPO/.gitignore"
 copy_file '.github/workflows/opencode.yml' "$TARGET_REPO/.github/workflows/opencode.yml"
-copy_file '.github/workflows/issues-triage.yml' "$TARGET_REPO/.github/workflows/issues-triage.yml"
 
 if [ "$INCLUDE_SCHEDULED" = 'true' ]; then
   copy_file '.github/workflows/opencode-scheduled.yml' "$TARGET_REPO/.github/workflows/opencode-scheduled.yml"


### PR DESCRIPTION
Cleaned up the stale bootstrap references and added a staged draft of the reviewer workflow outside `.github/workflows/`.

- Updated `README.md:18` and `README.md:34` so the docs no longer claim `oc-init` installs the missing `.github/workflows/issues-triage.yml`, and clarified that draft workflow content may live under `docs/`.
- Removed the dead `issues-triage` copy step from `oc-init:229`, so bootstrap behavior now matches the repository contents.
- Added `docs/opencode-review.workflow.yml:1` as a non-active draft of the dual-pass PR reviewer, with:
  - `pull_request` triggers for `opened`, `synchronize`, `reopened`, and `ready_for_review`
  - first pass on `github-copilot/gpt-5.4`
  - second pass on `github-copilot/claude-opus-4.6`
  - first-pass output serialized and passed into the second prompt
  - final review instructions that use `/oc` only when fixes are needed, otherwise return an LGTM-style result
- Verified there are no remaining `issues-triage` references in `README.md` or `oc-init`.

Changed files:
- `README.md`
- `oc-init`
- `docs/opencode-review.workflow.yml`

Natural next step:
1. Move `docs/opencode-review.workflow.yml` to `.github/workflows/opencode-review.yml` once workflow-file updates are allowed.

Closes #22

<a href="https://opencode.ai/s/ghJPPPno"><img width="200" alt="New%20session%20-%202026-03-23T09%3A35%3A52.277Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTAzLTIzVDA5OjM1OjUyLjI3N1o=.png?model=github-copilot/gpt-5.4&version=1.3.0&id=ghJPPPno" /></a>
[opencode session](https://opencode.ai/s/ghJPPPno)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/DavidGOrtega/auto-repo/actions/runs/23430597007)