### PR TITLE
separate coder and reviewer mentions

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -5,10 +5,6 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
   issue_comment:
     types: [created]
-  pull_request_review_comment:
-    types: [created]
-  pull_request_review:
-    types: [submitted]
 
 concurrency:
   group: opencode-review-${{ github.event.pull_request.number }}
@@ -26,16 +22,6 @@ jobs:
         github.event.issue.pull_request &&
         contains(github.event.comment.body, '/reviewer') &&
         contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
-      ) ||
-      (
-        github.event_name == 'pull_request_review_comment' &&
-        contains(github.event.comment.body, '/reviewer') &&
-        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
-      ) ||
-      (
-        github.event_name == 'pull_request_review' &&
-        contains(github.event.review.body, '/reviewer') &&
-        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)
       )
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -3,8 +3,6 @@ name: opencode
 on:
   issue_comment:
     types: [created]
-  pull_request_review_comment:
-    types: [created]
   pull_request_review:
     types: [submitted]
 
@@ -13,13 +11,6 @@ jobs:
     if: |
       (
         github.event_name == 'issue_comment' &&
-        (
-          contains(github.event.comment.body, '/coder')
-        ) &&
-        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
-      ) ||
-      (
-        github.event_name == 'pull_request_review_comment' &&
         (
           contains(github.event.comment.body, '/coder')
         ) &&


### PR DESCRIPTION
## Summary
- switch the coder workflow to the `/coder` trigger and restore the default OpenCode behavior by removing the custom coder prompt override
- switch the reviewer workflow to the `/reviewer` trigger so review runs only when explicitly requested on a PR thread and only hands off to the coder with `/coder` when changes are needed