### PR TITLE
simplify reviewer to pull request events

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -3,8 +3,6 @@ name: opencode-review
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-  issue_comment:
-    types: [created]
 
 concurrency:
   group: opencode-review-${{ github.event.pull_request.number }}
@@ -12,17 +10,6 @@ concurrency:
 
 jobs:
   review:
-    if: |
-      (
-        github.event_name == 'pull_request' &&
-        github.actor == 'github-actions[bot]'
-      ) ||
-      (
-        github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request &&
-        contains(github.event.comment.body, '/reviewer') &&
-        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
-      )
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -63,7 +50,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           model: github-copilot/gpt-5.4
-          mentions: /reviewer
           use_github_token: true
           prompt: |
             Review this pull request:
@@ -111,8 +97,8 @@ jobs:
 
             Final review rules:
             - If either pass finds actionable issues, set `verdict` to `needs_changes`.
-            - If `verdict` is `needs_changes`, include `/coder` exactly once at the end of the Markdown body.
-            - If `verdict` is `lgtm`, begin the Markdown body with `LGTM` and do not include `/coder` anywhere.
+            - If `verdict` is `needs_changes`, ask for changes clearly but do not include `/coder` or any other trigger command.
+            - If `verdict` is `lgtm`, begin the Markdown body with `LGTM`.
             - Include a short section that clearly calls out out-of-scope changes when present.
             - Keep the final review concise, technical, and actionable.
             - The Markdown in `${{ env.FINAL_REVIEW_FILE }}` must exactly match the `body` value in `${{ env.FINAL_REVIEW_JSON }}`.
@@ -124,7 +110,7 @@ jobs:
           import json
           from pathlib import Path
 
-          payload = json.loads(Path(".opencode/review/final-review.json").read_text())
+          payload = json.loads(Path("${FINAL_REVIEW_JSON}").read_text())
           verdict = payload.get("verdict")
           body = payload.get("body")
 
@@ -132,12 +118,10 @@ jobs:
               raise SystemExit(f"unexpected verdict: {verdict!r}")
           if not isinstance(body, str) or not body.strip():
               raise SystemExit("final review body must be a non-empty string")
-          if verdict == "needs_changes" and "/coder" not in body:
-              raise SystemExit("needs_changes review must include /coder")
-          if verdict == "lgtm" and "/coder" in body:
-              raise SystemExit("lgtm review must not include /coder")
+          if "/coder" in body:
+              raise SystemExit("review body must not include /coder")
 
-          Path(".opencode/review/final-review.md").write_text(body)
+          Path("${FINAL_REVIEW_FILE}").write_text(body)
           PY
 
       - name: Publish combined review comment on PR


### PR DESCRIPTION
## Summary
- make the reviewer run only on pull request lifecycle events and remove the fragile manual issue-comment trigger path
- stop the reviewer from emitting `/coder` automatically and keep reviewer output as review feedback only
- fix the reviewer validation step to use the temp-file paths already configured for the workflow