### PR TITLE
restore master token for chained workflows

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -47,7 +47,7 @@ jobs:
       - name: First review pass with GPT-5.4
         uses: anomalyco/opencode/github@latest
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.MASTER_GITHUB_TOKEN }}
         with:
           model: github-copilot/gpt-5.4
           use_github_token: true
@@ -75,7 +75,7 @@ jobs:
       - name: Second review pass with Claude Opus 4.6
         uses: anomalyco/opencode/github@latest
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.MASTER_GITHUB_TOKEN }}
         with:
           model: github-copilot/claude-opus-4-6
           use_github_token: true

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Run OpenCode
         uses: anomalyco/opencode/github@latest
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.MASTER_GITHUB_TOKEN }}
         with:
           model: github-copilot/gpt-5.4
           mentions: /coder

--- a/README.md
+++ b/README.md
@@ -108,6 +108,6 @@ If you want to install from a fork or a non-default ref, pass `--source-base-url
 - The workflows use repository-scoped defaults and do not depend on a hardcoded repository name.
 - Git author configuration is handled inside the workflows so automation can create commits when needed.
 - `oc-init` configures the repository so GitHub Actions can create and approve pull requests.
-- Do not expect OpenCode automation to create or edit workflow files automatically. GitHub blocks workflow-file writes unless the token has explicit workflow permission, so workflow changes should be reviewed and applied manually.
+- OpenCode uses the default `GITHUB_TOKEN` by default, but if you need workflow-triggered PR creation or chained automation between workflows, a dedicated higher-privilege token may still be required.
 - The scheduled workflow is optional; add it with `./oc-init --with-scheduled` or `bash -s -- --with-scheduled` if you want automated periodic repository reviews.
 - `--force` only affects files managed by `oc-init`; it does not touch unrelated repository content.


### PR DESCRIPTION
## Summary
- switch the coder and reviewer OpenCode steps back to `MASTER_GITHUB_TOKEN` so PR creation and chained workflow automation can trigger reliably
- update the bootstrap README to note that a higher-privilege token may still be required when workflow-created PRs need to trigger additional workflows