### PR TITLE
Fix oc-init triage workflow refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ This repository is the bootstrap source for that command.
 When you run `oc-init`, it:
 
 - resolves the target repo to the git root, even if you launch it from a nested folder
-- copies `AGENTS.md`, `.github/workflows/opencode.yml`, and `.github/workflows/issues-triage.yml`
+- copies `AGENTS.md` and `.github/workflows/opencode.yml`
 - optionally copies `.github/workflows/opencode-scheduled.yml` when you pass `--with-scheduled`
 - updates `.gitignore` by appending `.worktrees` only when that entry is missing
 - writes `*.oc-init-new` files instead of overwriting existing managed files, unless you pass `--force`
-- creates or updates the `triage` and `bug` labels through `gh`
+- creates or updates the `bug` label through `gh`
 - uploads the `OPENCODE_AUTH_JSON` secret from `~/.local/share/opencode/auth.json`
 - enables GitHub Actions workflow write permissions and pull request approval permissions
 - configures repository merge settings for squash-merge flow and branch cleanup
@@ -31,7 +31,6 @@ By default, existing repository content stays in place. `--force` only replaces 
 - `AGENTS.md` with repository workflow and contribution guidance for OpenCode sessions.
 - `.github/workflows/opencode.yml` to run OpenCode from issue comments and PR review activity.
 - `.github/workflows/opencode-scheduled.yml` to perform scheduled repository reviews.
-- `.github/workflows/issues-triage.yml` to label newly opened issues with `triage`.
 - `.gitignore` updated to include the local `.worktrees` convention used by the branching guide.
 - GitHub labels, secret, workflow permissions, PR approval permissions, and merge settings configured through `gh`.
 

--- a/oc-init
+++ b/oc-init
@@ -197,8 +197,6 @@ configure_github_repo() {
   gh auth status >/dev/null 2>&1 || fail 'gh must already be authenticated'
   [ -f "$OPENCODE_AUTH_PATH" ] || fail "missing OpenCode auth file: $OPENCODE_AUTH_PATH"
 
-  gh label create triage --repo "$repo_slug" --color FBCA04 --description 'Needs initial triage' --force >/dev/null
-  printf 'configured: label triage\n'
   gh label create bug --repo "$repo_slug" --color D73A4A --description "Something isn't working" --force >/dev/null
   printf 'configured: label bug\n'
 
@@ -226,7 +224,6 @@ REPO_SLUG=$(resolve_repo_slug "$ORIGIN_URL")
 copy_file 'AGENTS.md' "$TARGET_REPO/AGENTS.md"
 ensure_gitignore_entry "$TARGET_REPO/.gitignore"
 copy_file '.github/workflows/opencode.yml' "$TARGET_REPO/.github/workflows/opencode.yml"
-copy_file '.github/workflows/issues-triage.yml' "$TARGET_REPO/.github/workflows/issues-triage.yml"
 
 if [ "$INCLUDE_SCHEDULED" = 'true' ]; then
   copy_file '.github/workflows/opencode-scheduled.yml' "$TARGET_REPO/.github/workflows/opencode-scheduled.yml"


### PR DESCRIPTION
Removed the stale triage setup from `oc-init` so it matches the current workflow set.

- `oc-init:193` no longer creates the `triage` label, and `oc-init:224` no longer copies `.github/workflows/issues-triage.yml`
- `README.md:18`, `README.md:22`, and `README.md:31` now describe the bootstrap accurately, with only `opencode.yml` plus the optional scheduled workflow and the remaining `bug` label setup
- I verified there are no remaining `issues-triage` or `label triage` references in the repo
- I also ran `bash -n oc-init` to confirm the script still parses cleanly

Natural next step: let CI exercise the bootstrap flow against a target repo to confirm the generated setup is correct end to end.

Closes #46

<a href="https://opencode.ai/s/dqV1p6Zg"><img width="200" alt="New%20session%20-%202026-03-23T18%3A15%3A20.154Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTAzLTIzVDE4OjE1OjIwLjE1NFo=.png?model=github-copilot/gpt-5.4&version=1.3.0&id=dqV1p6Zg" /></a>
[opencode session](https://opencode.ai/s/dqV1p6Zg)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/DavidGOrtega/auto-repo/actions/runs/23453039907)