### PR TITLE
Fix docs to use `/coder` trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ If you want to install from a fork or a non-default ref, pass `--source-base-url
 2. Review any generated `*.oc-init-new` files and merge them with the target repository's existing files, or use `--force` when you explicitly want bootstrap-managed files replaced.
 3. Review `AGENTS.md` and adjust branch naming or review conventions if your team uses different defaults.
 4. Commit the copied files in the target repository.
-5. Open an issue or PR comment with `/oc` or `/opencode` to verify the workflow is active.
+5. Open an issue or PR comment with `/coder` to verify the workflow is active.
 
 ## Notes
 

--- a/oc-init
+++ b/oc-init
@@ -234,8 +234,8 @@ configure_github_repo "$REPO_SLUG"
 printf '\nNext steps:\n'
 if [ "$FORCE" = 'true' ]; then
   printf '1. Review the replaced files in git diff before committing.\n'
-  printf '2. Add /oc or /opencode to an issue or PR thread to verify the workflow.\n'
+  printf '2. Add /coder to an issue or PR thread to verify the workflow.\n'
 else
   printf '1. Review any *.oc-init-new files and merge them into your existing files.\n'
-  printf '2. Add /oc or /opencode to an issue or PR thread to verify the workflow.\n'
+  printf '2. Add /coder to an issue or PR thread to verify the workflow.\n'
 fi


### PR DESCRIPTION
I fixed the docs to match the actual supported trigger command, so the public instructions now point users at `/coder` instead of the unsupported `/oc` or `/opencode`.

- Updated the verification step in `README.md:103`
- Updated both post-install next-step messages in `oc-init:237` and `oc-init:240`
- Verified there are no remaining `/oc` or `/opencode` trigger instructions in those docs paths

If you want, I can also scan the rest of the repo for any prose that still implies `/oc` should work and normalize that too.

Closes #57

<a href="https://opencode.ai/s/5Lx7kd1O"><img width="200" alt="New%20session%20-%202026-03-23T18%3A38%3A52.115Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTAzLTIzVDE4OjM4OjUyLjExNVo=.png?model=github-copilot/gpt-5.4&version=1.3.0&id=5Lx7kd1O" /></a>
[opencode session](https://opencode.ai/s/5Lx7kd1O)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/DavidGOrtega/auto-repo/actions/runs/23454060525)