### PR TITLE
Add Superpowers via bootstrap config

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository is the bootstrap source for that command.
 When you run `oc-init`, it:
 
 - resolves the target repo to the git root, even if you launch it from a nested folder
-- copies `AGENTS.md` and `.github/workflows/opencode.yml`
+- copies `AGENTS.md`, `opencode.json`, and `.github/workflows/opencode.yml`
 - optionally copies `.github/workflows/opencode-scheduled.yml` when you pass `--with-scheduled`
 - updates `.gitignore` by appending `.worktrees` only when that entry is missing
 - writes `*.oc-init-new` files instead of overwriting existing managed files, unless you pass `--force`
@@ -29,6 +29,7 @@ By default, existing repository content stays in place. `--force` only replaces 
 ## What it includes
 
 - `AGENTS.md` with repository workflow and contribution guidance for OpenCode sessions.
+- `opencode.json` with the `superpowers` OpenCode plugin enabled.
 - `.github/workflows/opencode.yml` to run OpenCode from issue comments and PR review activity.
 - `.github/workflows/opencode-scheduled.yml` to perform scheduled repository reviews.
 - `.gitignore` updated to include the local `.worktrees` convention used by the branching guide.
@@ -98,13 +99,14 @@ If you want to install from a fork or a non-default ref, pass `--source-base-url
 
 1. From inside the target repo, run the remote `curl ... | bash` command, or use `./oc-init` from a local clone if you already have this repository checked out.
 2. Review any generated `*.oc-init-new` files and merge them with the target repository's existing files, or use `--force` when you explicitly want bootstrap-managed files replaced.
-3. Review `AGENTS.md` and adjust branch naming or review conventions if your team uses different defaults.
+3. Review `AGENTS.md` and `opencode.json`, and adjust branch naming, review conventions, or plugin configuration if your team uses different defaults.
 4. Commit the copied files in the target repository.
 5. Open an issue or PR comment with `/coder` to verify the workflow is active.
 
 ## Notes
 
 - The workflows use repository-scoped defaults and do not depend on a hardcoded repository name.
+- OpenCode reads the repository `opencode.json`, so the bundled `superpowers` plugin is available without modifying workflow files.
 - Git author configuration is handled inside the workflows so automation can create commits when needed.
 - `oc-init` configures the repository so GitHub Actions can create and approve pull requests.
 - OpenCode uses the default `GITHUB_TOKEN` by default, but if you need workflow-triggered PR creation or chained automation between workflows, a dedicated higher-privilege token may still be required.

--- a/oc-init
+++ b/oc-init
@@ -222,6 +222,7 @@ ORIGIN_URL=$(git -C "$TARGET_REPO" remote get-url origin 2>/dev/null || true)
 REPO_SLUG=$(resolve_repo_slug "$ORIGIN_URL")
 
 copy_file 'AGENTS.md' "$TARGET_REPO/AGENTS.md"
+copy_file 'opencode.json' "$TARGET_REPO/opencode.json"
 ensure_gitignore_entry "$TARGET_REPO/.gitignore"
 copy_file '.github/workflows/opencode.yml' "$TARGET_REPO/.github/workflows/opencode.yml"
 

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,5 @@
+{
+  "plugin": [
+    "superpowers@git+https://github.com/obra/superpowers.git"
+  ]
+}


### PR DESCRIPTION
Added Superpowers without touching the workflow files by making the bootstrap install OpenCode's plugin config directly.

- Added `opencode.json` with the `superpowers` plugin at `opencode.json:1`, following the upstream OpenCode install instructions from `obra/superpowers`
- Updated `oc-init:224` so bootstrapped repos now receive `opencode.json` alongside `AGENTS.md` and the existing workflow files
- Updated docs in `README.md:18`, `README.md:32`, `README.md:101`, and `README.md:108` to explain that Superpowers is now included through repository config rather than workflow edits
- Created and verified follow-up issue `#64` to handle the later workflow/action prompt changes: `https://github.com/DavidGOrtega/auto-repo/issues/64`

Verification:
- Validated `opencode.json` syntax with `python -m json.tool opencode.json`
- Confirmed only `README.md`, `oc-init`, and new `opencode.json` changed; no workflow files were modified

Natural next steps:
1. Let the automatic PR proceed for this branch
2. Tackle `#64` once workflow-permission changes are possible

Closes #62

<a href="https://opencode.ai/s/Pfx7MkDM"><img width="200" alt="New%20session%20-%202026-03-23T19%3A03%3A10.736Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTAzLTIzVDE5OjAzOjEwLjczNlo=.png?model=github-copilot/gpt-5.4&version=1.3.0&id=Pfx7MkDM" /></a>
[opencode session](https://opencode.ai/s/Pfx7MkDM)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/DavidGOrtega/auto-repo/actions/runs/23455085668)