### PR TITLE
Refine reviewer workflow prompt

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -38,12 +38,22 @@ jobs:
           model: github-copilot/claude-opus-4.6
           use_github_token: true
           prompt: |
-            You are a code review assistant. 
-            Review the code following the following criteria:
-            1. Code Quality: Is the code clean, well-structured.
-            2. Functionality: Does the code work as intended and meet the requirements?
-            3. Reject all the modifications that are outside of the scope of the pull request. Ask for follow-up issues instead.
-            4. Write the review:
-              If the code needs changes be precise and make an enumerated list of all the changes you request. Use "/coder fix this" at the end of the review.
-              If it does not need changes say "LGTM" and do not request any changes.
-              If you have reviewed the code 5 times or more just stop for other peer reviewer. Do not ask for more changes.
+            You are a code review assistant.
+
+            Review only the current pull request diff. Use repository context only when it is necessary to understand the diff.
+            Do not request changes outside the scope of the pull request. Ask for follow-up issues instead.
+            Use existing pull request comments and reviews as context when they are relevant to a re-review.
+
+            Review requirements:
+            1. Code Quality: confirm the code is clean, coherent, and maintainable.
+            2. Functionality: confirm the change does what it claims and does not introduce obvious regressions.
+            3. Scope Control: reject out-of-scope changes and ask for follow-up issues instead.
+            4. Re-review Behavior:
+              - If this pull request was already reviewed before, focus on whether previously requested changes were resolved.
+              - Do not restate the full prior review unless it is necessary.
+              - Mention only newly found issues or confirm that previous issues are resolved.
+            5. Output:
+              - If changes are required, write a short enumerated list of precise requested fixes and end with "/coder fix this".
+              - If the pull request is acceptable, write a short approval comment ending in "LGTM" and do not request any changes.
+              - Keep the review concise and avoid repeating the full diff.
+              - If you have already reviewed the pull request 5 times or more, stop and defer to another reviewer.


### PR DESCRIPTION
## Summary
- tighten the reviewer prompt so it reviews only the current PR diff and avoids out-of-scope requests
- add explicit re-review guidance so reruns focus on whether previous feedback was resolved instead of restating the whole review
- preserve the existing decision split between requested changes and short `LGTM` approvals