### PR TITLE
Clarify local pull workflow guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,18 @@ before starting any work, you MUST verify your current environment:
        git worktree add ./.worktrees/<branch_name> -b <branch_name>
       ```
     - **Switch Directory:** Change your working directory to the newly created path and perform all operations from there.
-  4. **Push your work once completed** Once the work is completed, do a final push to the repository.
-  5. **Pull the default branch to include latest changes** Once the branch is pushed, bring in the current default branch changes using a merge strategy if needed. Resolve conflicts manually. Never use rebase or anything that rewrites the git history.
+  4. **Update from origin before your final push when working locally** Before the final push from a local worktree, pull the latest remote state into your branch with `git pull origin <current-branch>` and resolve conflicts manually if they appear.
+  5. **Pull the default branch to include latest changes** Once the branch is pushed, bring in the current default branch changes with `git pull origin <default-branch>`. If conflicts appear, resolve them manually, complete the merge, and continue from that merged history. Never use rebase or anything that rewrites the git history.
+
+### Pull Conflict Handling
+
+When a working branch needs the latest `master` or `main`, prefer an explicit `git pull origin <default-branch>` so it is clear that the branch is incorporating the remote default branch and may require conflict resolution.
+
+- Before the final push from a local environment, also pull `origin/<current-branch>` into the working branch so remote updates are reconciled locally first.
+- Treat this as a merge-based update to the current branch.
+- If conflicts occur, resolve them manually, stage the resolved files, and complete the merge commit.
+- Do not replace this flow with rebase or other history-rewriting commands.
+- If you describe the update in logs or comments, say plainly that you pulled the default branch and resolved conflicts.
 
 ### Pull Request Summary
 


### PR DESCRIPTION
## Summary
- document that local worktrees must pull `origin/<current-branch>` before the final push so remote updates are reconciled locally first
- make default-branch updates explicit with `git pull origin <default-branch>` and manual conflict resolution
- reinforce that this workflow is merge-based and must not use rebase or other history-rewriting commands