### PR TITLE
Fix oc-init in-repo source resolution

### DIFF
--- a/oc-init
+++ b/oc-init
@@ -170,6 +170,25 @@ resolve_source_path() {
   printf '%s\n' "$fetched_path"
 }
 
+resolve_managed_source_path() {
+  local relative_path=$1
+  local script_root
+  local target_root
+  local fetched_path="$TEMP_DIR/bootstrap_${relative_path//\//__}"
+
+  script_root=$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || printf '%s\n' "$SCRIPT_DIR")
+  target_root=$(git -C "$TARGET_REPO" rev-parse --show-toplevel 2>/dev/null || printf '%s\n' "$TARGET_REPO")
+
+  if [ "$script_root" = "$target_root" ]; then
+    command -v curl >/dev/null 2>&1 || fail 'curl is required when oc-init runs from inside the target repository'
+    curl -fsSL "${SOURCE_BASE_URL%/}/$relative_path" -o "$fetched_path" || fail "failed to download: ${SOURCE_BASE_URL%/}/$relative_path"
+    printf '%s\n' "$fetched_path"
+    return
+  fi
+
+  resolve_source_path "$relative_path"
+}
+
 copy_file() {
   local relative_path=$1
   local target_path=$2
@@ -177,7 +196,7 @@ copy_file() {
   local source_path
   local existed_before='false'
 
-  source_path=$(resolve_source_path "$relative_path")
+  source_path=$(resolve_managed_source_path "$relative_path")
 
   target_dir=$(dirname -- "$target_path")
   mkdir -p -- "$target_dir"
@@ -208,7 +227,7 @@ merge_opencode_json() {
   local merged_path="$TEMP_DIR/opencode.json.merged"
   local existed_before='false'
 
-  source_path=$(resolve_source_path 'opencode.json')
+  source_path=$(resolve_managed_source_path 'opencode.json')
 
   mkdir -p -- "$(dirname -- "$target_path")"
 
@@ -304,7 +323,7 @@ reconcile_agents_md() {
   local reconciled_path="$TEMP_DIR/AGENTS.md.reconciled"
   local existed_before='false'
 
-  source_path=$(resolve_source_path 'AGENTS.md')
+  source_path=$(resolve_managed_source_path 'AGENTS.md')
 
   mkdir -p -- "$(dirname -- "$target_path")"
 

--- a/tests/oc-init-source-resolution.sh
+++ b/tests/oc-init-source-resolution.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_ROOT=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+TEMP_DIR=$(mktemp -d)
+
+cleanup() {
+  rm -rf -- "$TEMP_DIR"
+}
+
+trap cleanup EXIT
+
+BOOTSTRAP_DIR="$TEMP_DIR/bootstrap"
+TARGET_REPO="$TEMP_DIR/target"
+TEST_BIN="$TEMP_DIR/bin"
+TEST_HOME="$TEMP_DIR/home"
+
+mkdir -p -- "$BOOTSTRAP_DIR/.github/workflows" "$TARGET_REPO" "$TEST_BIN" "$TEST_HOME/.local/share/opencode"
+
+cat > "$BOOTSTRAP_DIR/AGENTS.md" <<'EOF'
+# Bootstrap AGENTS
+
+## Repo Guidance
+Repo-specific guidance lives here.
+
+## Bootstrap Marker
+Bootstrap-only guidance should appear in the reconciled result.
+
+### Superpowers Agent Rules
+
+This repository uses Superpowers for agent-driven work.
+
+- Agents must use the relevant Superpowers skill flow.
+- Reviewer approvals must start with `# REVIEW <sha>`.
+- Approval reviews end with `LGTM`.
+- Requested-change reviews end with `/coder fix this`.
+EOF
+
+cat > "$BOOTSTRAP_DIR/opencode.json" <<'EOF'
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": [
+    "superpowers@git+https://github.com/obra/superpowers.git"
+  ]
+}
+EOF
+
+cat > "$BOOTSTRAP_DIR/.github/workflows/opencode.yml" <<'EOF'
+name: opencode
+EOF
+
+git init "$TARGET_REPO" >/dev/null
+git -C "$TARGET_REPO" remote add origin https://github.com/example/target.git
+
+cat > "$TARGET_REPO/AGENTS.md" <<'EOF'
+# Target AGENTS
+
+## Local Rules
+Keep this repo-specific guidance.
+
+### Superpowers Agent Rules
+
+This repository uses Superpowers for agent-driven work.
+
+- Agents must use the relevant Superpowers skill flow.
+- Reviewer approvals must start with `# REVIEW <sha>`.
+- Approval reviews end with `LGTM`.
+- Requested-change reviews end with `/coder fix this`.
+EOF
+
+mkdir -p -- "$TARGET_REPO/.github/workflows"
+cat > "$TARGET_REPO/.github/workflows/opencode.yml" <<'EOF'
+name: existing-opencode
+EOF
+
+cat > "$TARGET_REPO/opencode.json" <<'EOF'
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "drachtio": {
+      "url": "https://gitmcp.io/drachtio/drachtio-server",
+      "enabled": true,
+      "type": "remote"
+    }
+  }
+}
+EOF
+
+printf '{"token":"test"}\n' > "$TEST_HOME/.local/share/opencode/auth.json"
+cp -- "$REPO_ROOT/oc-init" "$TARGET_REPO/oc-init"
+
+cat > "$TEST_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$TEST_BIN/gh"
+
+cat > "$TEST_BIN/opencode" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+prompt=''
+target_dir=''
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    run)
+      ;;
+    --format)
+      shift
+      ;;
+    --dir)
+      shift
+      target_dir=$1
+      ;;
+    *)
+      if [ -z "$prompt" ]; then
+        prompt=$1
+      fi
+      ;;
+  esac
+  shift
+done
+
+python3 - "$prompt" "$target_dir" <<'PY'
+import json
+import sys
+
+prompt = sys.argv[1]
+if 'Bootstrap-only guidance should appear in the reconciled result.' not in prompt:
+    raise SystemExit('bootstrap AGENTS content was not passed to opencode')
+
+print(json.dumps({"type": "text", "part": {"text": "# Reconciled AGENTS\n\n## Local Rules\nKeep this repo-specific guidance.\n\n## Bootstrap Marker\nBootstrap-only guidance should appear in the reconciled result.\n\n### Superpowers Agent Rules\n\nThis repository uses Superpowers for agent-driven work.\n\n- Agents must use the relevant Superpowers skill flow.\n- Reviewer approvals must start with `# REVIEW <sha>`.\n- Approval reviews end with `LGTM`.\n- Requested-change reviews end with `/coder fix this`.\n"}}))
+PY
+EOF
+chmod +x "$TEST_BIN/opencode"
+
+PATH="$TEST_BIN:$PATH" HOME="$TEST_HOME" bash "$TARGET_REPO/oc-init" --source-base-url "file://$BOOTSTRAP_DIR" "$TARGET_REPO" >/dev/null
+
+python3 - "$TARGET_REPO/opencode.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+data = json.loads(Path(sys.argv[1]).read_text())
+plugins = data.get('plugin')
+if plugins != ['superpowers@git+https://github.com/obra/superpowers.git']:
+    raise SystemExit(f"expected plugin list to be preserved, got: {plugins!r}")
+
+mcp = data.get('mcp', {}).get('drachtio', {})
+if mcp.get('url') != 'https://gitmcp.io/drachtio/drachtio-server':
+    raise SystemExit(f"expected existing mcp config to survive merge, got: {mcp!r}")
+PY
+
+python3 - "$TARGET_REPO/AGENTS.md" <<'PY'
+import sys
+from pathlib import Path
+
+text = Path(sys.argv[1]).read_text()
+if 'Bootstrap-only guidance should appear in the reconciled result.' not in text:
+    raise SystemExit('expected reconciled AGENTS.md to include bootstrap-only guidance')
+if 'Keep this repo-specific guidance.' not in text:
+    raise SystemExit('expected reconciled AGENTS.md to keep repo-specific guidance')
+PY
+
+python3 - "$TARGET_REPO/.github/workflows/opencode.yml.oc-init-new" <<'PY'
+import sys
+from pathlib import Path
+
+text = Path(sys.argv[1]).read_text().strip()
+if text != 'name: opencode':
+    raise SystemExit(f'expected workflow side file to come from bootstrap template, got: {text!r}')
+PY


### PR DESCRIPTION
Fixed `oc-init` for the reported case.

What changed:
- `oc-init`: added `resolve_managed_source_path()` and routed all managed files through it.
- When `oc-init` is executed from inside the target repo, it now fetches bootstrap-managed files from `--source-base-url` instead of accidentally using the target repo’s own `AGENTS.md`, `opencode.json`, or workflow files as the source.
- `tests/oc-init-source-resolution.sh`: added an end-to-end regression covering:
  - preserving repo `mcp` config while adding bootstrap `plugin`
  - using bootstrap content for `AGENTS.md`
  - generating workflow `*.oc-init-new` from the bootstrap template, not the existing target file

Root cause:
- `resolve_source_path()` preferred `"$SCRIPT_DIR/<file>"`.
- If `oc-init` was copied into the target repo and run there, `SCRIPT_DIR` pointed at the target repo, so reconciliation could read the target file as both source and destination.

Verification:
- `tests/oc-init-source-resolution.sh` passed
- `bash -n oc-init` passed

Files changed:
- `oc-init`
- `tests/oc-init-source-resolution.sh`

Closes #96

<a href="https://opencode.ai/s/nRPDOlgw"><img width="200" alt="New%20session%20-%202026-04-01T09%3A12%3A59.692Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTA0LTAxVDA5OjEyOjU5LjY5Mlo=.png?model=github-copilot/gpt-5.4&version=1.3.13&id=nRPDOlgw" /></a>
[opencode session](https://opencode.ai/s/nRPDOlgw)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/DavidGOrtega/auto-repo/actions/runs/23841176261)