### PR TITLE
Add default review workflow to oc-init

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository is the bootstrap source for that command.
 When you run `oc-init`, it:
 
 - resolves the target repo to the git root, even if you launch it from a nested folder
-- reconciles `AGENTS.md`, `opencode.json`, and copies `.github/workflows/opencode.yml`
+- reconciles `AGENTS.md`, `opencode.json`, and copies `.github/workflows/opencode.yml` plus `.github/workflows/opencode-review.yml`
 - optionally copies `.github/workflows/opencode-scheduled.yml` when you pass `--with-scheduled`
 - updates `.gitignore` by appending `.worktrees` only when that entry is missing
 - writes `*.oc-init-new` files for existing managed files other than `AGENTS.md` and `opencode.json`, unless you pass `--force`
@@ -30,7 +30,8 @@ By default, existing repository content stays in place. `AGENTS.md` is reconcile
 
 - `AGENTS.md` reconciled with repository workflow and contribution guidance for OpenCode sessions.
 - `opencode.json` merged so the `superpowers` OpenCode plugin stays enabled alongside repo-specific config.
-- `.github/workflows/opencode.yml` to run OpenCode from issue comments and PR review activity.
+- `.github/workflows/opencode.yml` to run OpenCode from issue comments.
+- `.github/workflows/opencode-review.yml` to run OpenCode on pull request review activity.
 - `.github/workflows/opencode-scheduled.yml` to perform scheduled repository reviews.
 - `.gitignore` updated to include the local `.worktrees` convention used by the branching guide.
 - GitHub labels, secret, workflow permissions, PR approval permissions, and merge settings configured through `gh`.

--- a/oc-init
+++ b/oc-init
@@ -21,7 +21,7 @@ If TARGET_REPO points at a subdirectory inside a git repository, oc-init
 installs into that repository root.
 
 Options:
-  --with-scheduled  Include the scheduled review workflow.
+  --with-scheduled  Include the scheduled repository review workflow.
   --force           Overwrite managed target files instead of writing *.oc-init-new merge copies.
   --source-base-url Download bootstrap files from this base URL when they are not available locally.
   -h, --help        Show this help text.
@@ -546,6 +546,7 @@ REPO_SLUG=$(resolve_repo_slug "$ORIGIN_URL")
 install_prerequisite_bootstrap_files
 ensure_gitignore_entry "$TARGET_REPO/.gitignore"
 copy_file '.github/workflows/opencode.yml' "$TARGET_REPO/.github/workflows/opencode.yml"
+copy_file '.github/workflows/opencode-review.yml' "$TARGET_REPO/.github/workflows/opencode-review.yml"
 
 if [ "$INCLUDE_SCHEDULED" = 'true' ]; then
   copy_file '.github/workflows/opencode-scheduled.yml' "$TARGET_REPO/.github/workflows/opencode-scheduled.yml"

--- a/tests/oc-init-workflows.sh
+++ b/tests/oc-init-workflows.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_ROOT=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+OC_INIT="$REPO_ROOT/oc-init"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+assert_exists() {
+  local path=$1
+  [ -f "$path" ] || fail "expected file to exist: $path"
+}
+
+assert_missing() {
+  local path=$1
+  [ ! -e "$path" ] || fail "expected path to be absent: $path"
+}
+
+make_stub_bin() {
+  local bin_dir=$1
+
+  mkdir -p -- "$bin_dir"
+
+  cat <<'EOF' > "$bin_dir/gh"
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "$bin_dir/gh"
+
+  cat <<'EOF' > "$bin_dir/opencode"
+#!/usr/bin/env bash
+if [ "${1:-}" = 'run' ]; then
+  printf '{"type":"text","part":{"text":"# Reconciled\n\n## Repo\n\nKeep repo guidance.\n"}}\n'
+fi
+exit 0
+EOF
+  chmod +x "$bin_dir/opencode"
+}
+
+make_target_repo() {
+  local target_dir=$1
+
+  mkdir -p -- "$target_dir"
+  git init "$target_dir" >/dev/null
+  git -C "$target_dir" remote add origin https://github.com/example/target.git
+}
+
+run_oc_init() {
+  local temp_dir=$1
+  shift
+
+  PATH="$temp_dir/bin:$PATH" \
+  HOME="$temp_dir/home" \
+  "$OC_INIT" "$temp_dir/target" "$@" >/dev/null
+}
+
+test_installs_default_workflows() {
+  local temp_dir
+  temp_dir=$(mktemp -d)
+  trap 'rm -rf -- "$temp_dir"' RETURN
+
+  mkdir -p -- "$temp_dir/home/.local/share/opencode"
+  printf '{}' > "$temp_dir/home/.local/share/opencode/auth.json"
+  make_stub_bin "$temp_dir/bin"
+  make_target_repo "$temp_dir/target"
+
+  run_oc_init "$temp_dir"
+
+  assert_exists "$temp_dir/target/.github/workflows/opencode.yml"
+  assert_exists "$temp_dir/target/.github/workflows/opencode-review.yml"
+  assert_missing "$temp_dir/target/.github/workflows/opencode-scheduled.yml"
+}
+
+test_installs_scheduled_workflow_only_with_flag() {
+  local temp_dir
+  temp_dir=$(mktemp -d)
+  trap 'rm -rf -- "$temp_dir"' RETURN
+
+  mkdir -p -- "$temp_dir/home/.local/share/opencode"
+  printf '{}' > "$temp_dir/home/.local/share/opencode/auth.json"
+  make_stub_bin "$temp_dir/bin"
+  make_target_repo "$temp_dir/target"
+
+  run_oc_init "$temp_dir" --with-scheduled
+
+  assert_exists "$temp_dir/target/.github/workflows/opencode.yml"
+  assert_exists "$temp_dir/target/.github/workflows/opencode-review.yml"
+  assert_exists "$temp_dir/target/.github/workflows/opencode-scheduled.yml"
+}
+
+test_installs_default_workflows
+test_installs_scheduled_workflow_only_with_flag
+
+printf 'PASS: oc-init workflow installation\n'


### PR DESCRIPTION
Fixed `oc-init` so the default install now includes `.github/workflows/opencode-review.yml` alongside `.github/workflows/opencode.yml`.

What changed:
- `oc-init`: copies `opencode-review.yml` by default
- `README.md`: documents the default workflow set correctly
- `tests/oc-init-workflows.sh`: adds a regression test covering
  - default install: `opencode.yml` + `opencode-review.yml`
  - `--with-scheduled`: also includes `opencode-scheduled.yml`

Root cause:
- The bootstrap repo already contained `opencode-review.yml`, but `oc-init` had no install path for it.

Verification:
- `bash tests/oc-init-workflows.sh`
- `bash -n oc-init tests/oc-init-workflows.sh`

Both passed.

Closes #96

<a href="https://opencode.ai/s/54Ia69nm"><img width="200" alt="New%20session%20-%202026-04-01T09%3A50%3A46.967Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTA0LTAxVDA5OjUwOjQ2Ljk2N1o=.png?model=github-copilot/gpt-5.4&version=1.3.13&id=54Ia69nm" /></a>
[opencode session](https://opencode.ai/s/54Ia69nm)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/DavidGOrtega/auto-repo/actions/runs/23842692778)