### PR TITLE
feat: add issue triage workflow

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,88 @@
+name: triage
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Restore OpenCode credentials
+        env:
+          OPENCODE_AUTH_JSON: ${{ secrets.OPENCODE_AUTH_JSON }}
+        run: |
+          mkdir -p "$HOME/.local/share/opencode"
+          printf '%s' "$OPENCODE_AUTH_JSON" > "$HOME/.local/share/opencode/auth.json"
+          chmod 600 "$HOME/.local/share/opencode/auth.json"
+
+      - name: Configure git author
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - uses: anomalyco/opencode/github@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          model: github-copilot/gpt-5.4
+          use_github_token: true
+          prompt: |
+            A new issue was just opened. Perform the following tasks, then post a SINGLE comment if needed.
+
+            First, fetch the issue details:
+            gh issue view ${{ github.event.issue.number }} --repo ${{ github.repository }}
+
+            ---
+
+            TASK 1: FIND RELATED ISSUES
+
+            Search existing open issues for duplicates or related issues (exclude #${{ github.event.issue.number }}).
+            Use: gh issue list --repo ${{ github.repository }} --state open --limit 50
+            Then view promising candidates with: gh issue view <number> --repo ${{ github.repository }}
+
+            Look for:
+            1. Similar titles or descriptions
+            2. Same error messages or symptoms
+            3. Related functionality or components
+            4. Similar feature requests
+
+            ---
+
+            TASK 2: DETECT CONFIGURATION QUESTIONS
+
+            Determine if this issue is a question about configuration, installation, setup, or usage rather than a bug report or feature request.
+
+            If it IS a configuration question:
+            1. Search the repository for relevant documentation (README.md, docs/, CONTRIBUTING.md, etc.)
+            2. Provide a direct, helpful answer based on the actual documentation
+            3. Link to the specific documentation files or sections that are relevant
+
+            ---
+
+            POSTING YOUR COMMENT:
+
+            Post at most ONE comment on issue #${{ github.event.issue.number }} combining all findings.
+            Use gh issue comment ${{ github.event.issue.number }} --repo ${{ github.repository }} --body "<comment>"
+
+            Build the comment as follows:
+
+            If duplicates/related issues were found, include a section:
+            **Related issues:**
+            This issue might be related to existing issues. Please check:
+            - #[issue_number]: [brief description of similarity]
+
+            If it is a configuration question, include a section with direct help:
+            **Quick answer:**
+            [Your helpful answer based on the repo documentation]
+            For more details, see [link to relevant doc file].
+
+            If neither duplicates were found AND it is not a configuration question, do NOT comment at all.


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow that triggers on issue creation
- Searches existing open issues for duplicates/related issues and comments with links
- Detects configuration/setup questions and responds with direct help from repo docs
- Uses standard GITHUB_TOKEN (no MASTER_GITHUB_TOKEN needed)
- Posts a single comment combining findings, or no comment if nothing to report