### PR TITLE
Consolidate install+config into one script

### DIFF
--- a/.github/scripts/install-opencode.sh
+++ b/.github/scripts/install-opencode.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -eu
 
+curl -fsSL https://opencode.ai/install | bash
+
 mkdir -p "$HOME/.config/opencode"
 cat > "$HOME/.config/opencode/opencode.json" <<'CONFIG'
 {

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -19,10 +19,7 @@ jobs:
           token: ${{ secrets.MASTER_GITHUB_TOKEN }}
 
       - name: Install OpenCode
-        run: curl -fsSL https://opencode.ai/install | bash
-          
-      - name: Restore OpenCode config
-        run: ./.github/scripts/restore-opencode-config.sh
+        run: ./.github/scripts/install-opencode.sh
 
       - name: Configure git author
         run: |

--- a/.github/workflows/opencode-scheduled.yml
+++ b/.github/workflows/opencode-scheduled.yml
@@ -16,8 +16,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Restore OpenCode config
-        run: ./.github/scripts/restore-opencode-config.sh
+      - name: Install OpenCode
+        run: ./.github/scripts/install-opencode.sh
 
       - name: Configure git author
         run: |

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -62,8 +62,8 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.MASTER_GITHUB_TOKEN }}
 
-      - name: Restore OpenCode config
-        run: ./.github/scripts/restore-opencode-config.sh
+      - name: Install OpenCode
+        run: ./.github/scripts/install-opencode.sh
 
       - name: Configure git author
         run: |

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -16,16 +16,13 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Restore OpenCode config
-        run: ./.github/scripts/restore-opencode-config.sh
+      - name: Install OpenCode
+        run: ./.github/scripts/install-opencode.sh
 
       - name: Configure git author
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-      - name: Install OpenCode
-        run: curl -fsSL https://opencode.ai/install | bash
 
       - name: Run OpenCode triage
         env:


### PR DESCRIPTION
All done. Here's what changed:

- **Created** `.github/scripts/install-opencode.sh` — combines `curl -fsSL https://opencode.ai/install | bash` with the config restoration into a single script
- **Deleted** `.github/scripts/restore-opencode-config.sh`
- **Updated 4 workflows** to use the single `Install OpenCode` step:
  - `opencode.yml` — replaced separate restore step
  - `opencode-scheduled.yml` — replaced separate restore step
  - `opencode-review.yml` — merged install + restore into one step
  - `triage.yml` — merged install + restore into one step

No remaining references to `restore-opencode-config.sh` anywhere in the repo.

Closes #114

<a href="https://opencode.ai/s/Hv01dnx9"><img width="200" alt="New%20session%20-%202026-04-03T16%3A08%3A13.161Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTA0LTAzVDE2OjA4OjEzLjE2MVo=.png?model=ZCode/glm-5.1&version=1.3.13&id=Hv01dnx9" /></a>
[opencode session](https://opencode.ai/s/Hv01dnx9)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/DavidGOrtega/auto-repo/actions/runs/23952874858)