### PR TITLE
Simplify reviewer to comment-only flow

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -66,6 +66,9 @@ jobs:
             - If changes are required, use a short numbered list of precise fixes.
             - Append `/coder fix this` only when changes are required and the reviewed commit includes the exact trailer `By: coder`.
             - Do not include markdown fences or any extra text before or after the final review body.
+            - Do not describe your investigation, tool usage, reasoning, or intermediate findings.
+            - Do not include preambles like "Let me", "I need to", "I found", or any analysis transcript.
+            - Start your response immediately with `# REVIEW <sha>`.
           EOF
           perl -0pi -e 's/#PR_NUMBER#/'"$pr_number"'/g' "$prompt_file"
           opencode run -m ZCode/glm-5.1 "$(cat "$prompt_file")" > "$review_file"


### PR DESCRIPTION
## Summary
- simplify the reviewer workflow to always post a single PR comment instead of formal GitHub review states
- remove the structured JSON parsing path that was causing fragile reviewer failures
- keep the review format contract, including `/coder fix this` only when the reviewed commit is marked with `By: coder`