### PR TITLE
Use `gh pr review` instead of `gh pr comment`

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -100,9 +100,9 @@ jobs:
           opencode run -m ZCode/glm-5.1 "$(cat "$prompt_file")" > "$review_file"
           if [ -s "$review_file" ]; then
             if grep -qE '(^|\s)LGTM(\s|$|\.|,)' "$review_file"; then
-              gh pr review "$pr_number" --approve --body-file "$review_file"
+              GH_TOKEN="${{ github.token }}" gh pr review "$pr_number" --approve --body-file "$review_file"
             else
-              gh pr review "$pr_number" --request-changes --body-file "$review_file"
+              GH_TOKEN="${{ github.token }}" gh pr review "$pr_number" --request-changes --body-file "$review_file"
             fi
           else
             echo "::warning::Review file was empty, skipping review"

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -99,7 +99,11 @@ jobs:
           perl -0pi -e 's/#PR_NUMBER#/'"$pr_number"'/g' "$prompt_file"
           opencode run -m ZCode/glm-5.1 "$(cat "$prompt_file")" > "$review_file"
           if [ -s "$review_file" ]; then
-            gh pr comment "$pr_number" --body-file "$review_file"
+            if grep -qE '(^|\s)LGTM(\s|$|\.|,)' "$review_file"; then
+              gh pr review "$pr_number" --approve --body-file "$review_file"
+            else
+              gh pr review "$pr_number" --request-changes --body-file "$review_file"
+            fi
           else
-            echo "::warning::Review file was empty, skipping comment"
+            echo "::warning::Review file was empty, skipping review"
           fi


### PR DESCRIPTION
**Root cause:** The workflow used `gh pr comment` (line 102) which only posts a plain comment — not a formal PR review with approve/request-changes status.

**Fix:** Replaced `gh pr comment` with `gh pr review` that:
- Uses `--approve` when the review contains `LGTM`
- Uses `--request-changes` otherwise

This ensures the reviewer explicitly submits an approving review or requests changes via GitHub's review system, matching the `github-flow/SKILL.md` conventions.

Closes #149

<a href="https://opencode.ai/s/wRVqoBep"><img width="200" alt="New%20session%20-%202026-04-06T22%3A40%3A53.105Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTA0LTA2VDIyOjQwOjUzLjEwNVo=.png?model=ZCode/glm-5.1&version=1.3.17&id=wRVqoBep" /></a>
[opencode session](https://opencode.ai/s/wRVqoBep)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/DavidGOrtega/auto-repo/actions/runs/24054764824)