### PR TITLE
Wrap timeout output in fromJSON() to cast to int

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -48,7 +48,7 @@ jobs:
     needs: parse-invocation
     if: needs.parse-invocation.result == 'success'
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ needs.parse-invocation.outputs.timeout || 20 }}
+    timeout-minutes: ${{ fromJSON(needs.parse-invocation.outputs.timeout || '20') }}
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
Fixed. The `fromJSON()` wrapper converts the string output to an integer. When `timeout=60` is parsed, `fromJSON("60")` → `60` (number). When no timeout is specified, `fromJSON("20")` → `20` (number).

Closes #155

<a href="https://opencode.ai/s/sQSJa8xT"><img width="200" alt="New%20session%20-%202026-04-08T13%3A29%3A22.216Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTA0LTA4VDEzOjI5OjIyLjIxNlo=.png?model=ZCode/glm-5.1&version=1.4.0&id=sQSJa8xT" /></a>
[opencode session](https://opencode.ai/s/sQSJa8xT)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/DavidGOrtega/auto-repo/actions/runs/24137965199)